### PR TITLE
Use context manager and utf-8 encoding for file access

### DIFF
--- a/chrome_bookmarks/__init__.py
+++ b/chrome_bookmarks/__init__.py
@@ -66,14 +66,17 @@ class Bookmarks:
 
     def __init__(self, path):
         self.path = path
-        self.data = json.loads(open(path).read())
+        with open(path, encoding="utf-8") as f:
+            self.data = json.load(f)
         self.attrList = self.processRoots()
         self.urls = self.attrList["urls"]
         self.folders = self.attrList["folders"]
 
     def processRoots(self):
         attrList = {"urls": [], "folders": []}
-        for key, value in json.loads(open(path).read())["roots"].items():
+        with open(path, encoding="utf-8") as f:
+            roots_data = json.load(f)
+        for key, value in roots_data["roots"].items():
             if "children" in value:
                 self.processTree(attrList, value["children"])
         return attrList


### PR DESCRIPTION
I ran into a problem with invalid encodings and something that seemed like deadlocks. This should fix it.